### PR TITLE
Fix cronjobs not launching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
         vim \
         sqlite3 \
 	&& ln -s $(which pip3) /usr/local/bin/pip \
+    && ln -s $(which python3) /usr/bin/python \
     && pip install --no-cache-dir --upgrade pip setuptools gunicorn gevent \
     && pip install --no-cache-dir --upgrade -r ${PKG_DIR}/requirements.txt \
     && pip install --no-cache-dir -e ${PKG_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
         cron \
         vim \
         sqlite3 \
-	&& ln -s $(which pip3) /usr/local/bin/pip \
+    && ln -s $(which pip3) /usr/local/bin/pip \
     && ln -s $(which python3) /usr/bin/python \
     && pip install --no-cache-dir --upgrade pip setuptools gunicorn gevent \
     && pip install --no-cache-dir --upgrade -r ${PKG_DIR}/requirements.txt \

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 
 `Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
+* Fix ``Dockerfile`` with symlink python => python3
+* Add canarieapi path to cron command
 
 `0.4.2 <https://github.com/Ouranosinc/CanarieAPI/tree/0.4.2>`_ (2020-03-27)
 ------------------------------------------------------------------------------------

--- a/canarieapi-cron
+++ b/canarieapi-cron
@@ -1,2 +1,2 @@
-* * * * * root python -c 'from canarieapi import logparser; logparser.cron_job()' >> /var/log/logparser_cron.log 2>&1
-* * * * * root python -c 'from canarieapi import monitoring; monitoring.cron_job()' >> /var/log/monitoring_cron.log 2>&1
+* * * * * root python -c 'import sys; sys.path.insert(0, "/opt/local/src/CanarieAPI/canarieapi"); from canarieapi import logparser; logparser.cron_job()' >> /var/log/logparser_cron.log 2>&1
+* * * * * root python -c 'import sys; sys.path.insert(0, "/opt/local/src/CanarieAPI/canarieapi"); from canarieapi import monitoring; monitoring.cron_job()' >> /var/log/monitoring_cron.log 2>&1

--- a/canarieapi-cron
+++ b/canarieapi-cron
@@ -1,2 +1,2 @@
-* * * * * root python -c 'from canarieapi import logparser; logparser.cron_job()' >> /var/log/logparser_cron.log 2>&1
-* * * * * root python -c 'from canarieapi import monitoring; monitoring.cron_job()' >> /var/log/monitoring_cron.log 2>&1
+* * * * * root python3 -c 'from canarieapi import logparser; logparser.cron_job()' >> /var/log/logparser_cron.log 2>&1
+* * * * * root python3 -c 'from canarieapi import monitoring; monitoring.cron_job()' >> /var/log/monitoring_cron.log 2>&1

--- a/canarieapi-cron
+++ b/canarieapi-cron
@@ -1,2 +1,2 @@
-* * * * * root python3 -c 'from canarieapi import logparser; logparser.cron_job()' >> /var/log/logparser_cron.log 2>&1
-* * * * * root python3 -c 'from canarieapi import monitoring; monitoring.cron_job()' >> /var/log/monitoring_cron.log 2>&1
+* * * * * root python -c 'from canarieapi import logparser; logparser.cron_job()' >> /var/log/logparser_cron.log 2>&1
+* * * * * root python -c 'from canarieapi import monitoring; monitoring.cron_job()' >> /var/log/monitoring_cron.log 2>&1

--- a/canarieapi/app_object.py
+++ b/canarieapi/app_object.py
@@ -10,7 +10,7 @@ from flask import Flask
 from os import environ
 
 # -- Project specific --------------------------------------------------------
-import default_configuration
+from . import default_configuration
 from canarieapi.reverse_proxied import ReverseProxied
 
 

--- a/canarieapi/app_object.py
+++ b/canarieapi/app_object.py
@@ -12,8 +12,8 @@ from os import environ
 # -- Project specific --------------------------------------------------------
 # 'default_configuration' is imported like so instead of 'from canarieapi ...' 
 # to allow override on the local configurations by the docker image
-# Make sure to add the local path with sys.path.insert(0, SOURCE) when calling the process
-# (like in canariaapi-cron command)
+# Make sure to add the local path with sys.path.insert(0, SOURCE) when calling the process if necessary
+# (like in canarieapi-cron command)
 import default_configuration
 from canarieapi.reverse_proxied import ReverseProxied
 

--- a/canarieapi/app_object.py
+++ b/canarieapi/app_object.py
@@ -10,7 +10,11 @@ from flask import Flask
 from os import environ
 
 # -- Project specific --------------------------------------------------------
-from . import default_configuration
+# 'default_configuration' is imported like so instead of 'from canarieapi ...' 
+# to allow override on the local configurations by the docker image
+# Make sure to add the local path with sys.path.insert(0, SOURCE) when calling the process
+# (like in canariaapi-cron command)
+import default_configuration
 from canarieapi.reverse_proxied import ReverseProxied
 
 


### PR DESCRIPTION
Monitoring (Stats and Status) were not working in my recent deployment with 0.4.2.

After investigation, found that the cron jobs weren't running because of the change of python versions.

Theses are the 2 smalls fixes I found which worked on my end.

However, I don't know if simply using python3 in the cron file could cause other problems down the line, or if there's a cleaner way to manage this through the Dockerfile.