### PR TITLE
Fix default config import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
         build-essential \
         python3-dev \
         python3-pip \
+        curl \
         cron \
         vim \
         sqlite3 \

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 `Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 * Fix ``Dockerfile`` with symlink python => python3
-* Add canarieapi path to cron command
+* Fix how ``default_configuration`` is imported by ``app_object.py``
 
 `0.4.2 <https://github.com/Ouranosinc/CanarieAPI/tree/0.4.2>`_ (2020-03-27)
 ------------------------------------------------------------------------------------

--- a/canarieapi-cron
+++ b/canarieapi-cron
@@ -1,2 +1,2 @@
-* * * * * root python -c 'import sys; sys.path.insert(0, "/opt/local/src/CanarieAPI/canarieapi"); from canarieapi import logparser; logparser.cron_job()' >> /var/log/logparser_cron.log 2>&1
-* * * * * root python -c 'import sys; sys.path.insert(0, "/opt/local/src/CanarieAPI/canarieapi"); from canarieapi import monitoring; monitoring.cron_job()' >> /var/log/monitoring_cron.log 2>&1
+* * * * * root python -c 'from canarieapi import logparser; logparser.cron_job()' >> /var/log/logparser_cron.log 2>&1
+* * * * * root python -c 'from canarieapi import monitoring; monitoring.cron_job()' >> /var/log/monitoring_cron.log 2>&1

--- a/canarieapi/app_object.py
+++ b/canarieapi/app_object.py
@@ -10,6 +10,7 @@ from flask import Flask
 from os import environ
 
 # -- Project specific --------------------------------------------------------
+from canarieapi import default_configuration
 from canarieapi.reverse_proxied import ReverseProxied
 
 
@@ -24,10 +25,9 @@ APP.logger.setLevel(logging.DEBUG)
 APP.wsgi_app = ReverseProxied(APP.wsgi_app)
 
 # Config
+APP.config.from_object(default_configuration)
 if 'CANARIE_API_CONFIG_FN' in environ:
     APP.config.from_envvar('CANARIE_API_CONFIG_FN')
     APP.logger.info('Loading custom configuration from "{0}"'.format(environ['CANARIE_API_CONFIG_FN']))
 else:
-    from canarieapi import default_configuration
-    APP.config.from_object(default_configuration)
     APP.logger.info('Using default configuration')

--- a/canarieapi/app_object.py
+++ b/canarieapi/app_object.py
@@ -10,11 +10,6 @@ from flask import Flask
 from os import environ
 
 # -- Project specific --------------------------------------------------------
-# 'default_configuration' is imported like so instead of 'from canarieapi ...' 
-# to allow override on the local configurations by the docker image
-# Make sure to add the local path with sys.path.insert(0, SOURCE) when calling the process if necessary
-# (like in canarieapi-cron command)
-import default_configuration
 from canarieapi.reverse_proxied import ReverseProxied
 
 
@@ -29,9 +24,10 @@ APP.logger.setLevel(logging.DEBUG)
 APP.wsgi_app = ReverseProxied(APP.wsgi_app)
 
 # Config
-APP.config.from_object(default_configuration)
 if 'CANARIE_API_CONFIG_FN' in environ:
     APP.config.from_envvar('CANARIE_API_CONFIG_FN')
     APP.logger.info('Loading custom configuration from "{0}"'.format(environ['CANARIE_API_CONFIG_FN']))
 else:
+    from canarieapi import default_configuration
+    APP.config.from_object(default_configuration)
     APP.logger.info('Using default configuration')


### PR DESCRIPTION
- Rolled back cron command
- Changed how `default_configuration `is imported

I tested with and without `CANARIE_API_CONFIG_FN ` and everything worked as expected on my end.

Also saw that nginx's healthcheck always came back as unhealthy when using it in GIN, even though everything was working fine.

Turns out, the new version doesn't install curl, compared to inhouse version 0.4.0, so I added it back, but is it something we wish to keep? 