### PR TITLE
fix webapp errors caused by mismatching setup and expected Flask definitions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@ History
 `Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
+* Fix ``Flask`` requirements and expected configurations to setup the web application.
+* Fix broken example URL in ``canarieapi/default_configuration.py``.
+* Fix linting and variable name shadowing within scoped or built-in context.
+
 `0.4.3 <https://github.com/Ouranosinc/CanarieAPI/tree/0.4.3>`_ (2020-05-01)
 ------------------------------------------------------------------------------------
 * Fix ``Dockerfile`` with symlink python => python3

--- a/bin/gunicorn
+++ b/bin/gunicorn
@@ -1,4 +1,3 @@
-import sys
 import gunicorn.app.wsgiapp
 import sys
 

--- a/canarieapi/default_configuration.py
+++ b/canarieapi/default_configuration.py
@@ -35,18 +35,18 @@ SERVICES = {
             'route': '/name/service/.*'
         },
         'redirect': {
-            'doc': 'https://science.canarie.ca/researchsoftware/home/main.html',
-            'releasenotes': 'https://science.canarie.ca/researchsoftware/home/main.html',
-            'support': 'https://science.canarie.ca/researchsoftware/home/main.html',
-            'source': 'https://science.canarie.ca/researchsoftware/home/main.html',
-            'tryme': 'https://science.canarie.ca/researchsoftware/home/main.html',
-            'licence': 'https://science.canarie.ca/researchsoftware/home/main.html',
-            'provenance': 'https://science.canarie.ca/researchsoftware/home/main.html'
+            'doc': 'https://www.canarie.ca/software/',
+            'releasenotes': 'https://www.canarie.ca/software/',
+            'support': 'https://www.canarie.ca/software/',
+            'source': 'https://www.canarie.ca/software/',
+            'tryme': 'https://www.canarie.ca/software/',
+            'licence': 'https://www.canarie.ca/software/',
+            'provenance': 'https://www.canarie.ca/software/'
         },
         'monitoring': {
             'Component': {
                 'request': {
-                    'url': 'https://science.canarie.ca/researchsoftware/home/main.html'
+                    'url': 'https://www.canarie.ca/software/'
                 }
             }
         }
@@ -70,19 +70,19 @@ PLATFORMS = {
             'route': '/pf_name/platform/.*'
         },
         'redirect': {
-            'doc': 'https://science.canarie.ca/researchsoftware/home/main.html',
-            'releasenotes': 'https://science.canarie.ca/researchsoftware/home/main.html',
-            'support': 'https://science.canarie.ca/researchsoftware/home/main.html',
-            'source': 'https://science.canarie.ca/researchsoftware/home/main.html',
-            'tryme': 'https://science.canarie.ca/researchsoftware/home/main.html',
-            'licence': 'https://science.canarie.ca/researchsoftware/home/main.html',
-            'provenance': 'https://science.canarie.ca/researchsoftware/home/main.html',
-            'factsheet': 'https://science.canarie.ca/researchsoftware/home/main.html'
+            'doc': 'https://www.canarie.ca/software/',
+            'releasenotes': 'https://www.canarie.ca/software/',
+            'support': 'https://www.canarie.ca/software/',
+            'source': 'https://www.canarie.ca/software/',
+            'tryme': 'https://www.canarie.ca/software/',
+            'licence': 'https://www.canarie.ca/software/',
+            'provenance': 'https://www.canarie.ca/software/',
+            'factsheet': 'https://www.canarie.ca/software/'
         },
         'monitoring': {
             'Component': {
                 'request': {
-                    'url': 'https://science.canarie.ca/researchsoftware/home/main.html'
+                    'url': 'https://www.canarie.ca/software/'
                 }
             }
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bumpversion==0.5.3
-flask
+flask>=2.2
 gevent
 gunicorn
 jsonschema


### PR DESCRIPTION
## Changes

* Fix ``Flask`` requirements and expected configurations to setup the web application.
* Fix broken example URL in ``canarieapi/default_configuration.py``.
* Fix linting and variable name shadowing within scoped or built-in context.

## Example Error Log

```
proxy              | [2023-01-31 19:37:01 +0000] [37] [DEBUG] GET /canarie/
proxy              | [2023-01-31 19:37:01,708] [37] [INFO] app_object : Disconnecting from database
proxy              | [2023-01-31 19:37:01,709] [37] [DEBUG] app_object : Using db filename : /opt/local/src/CanarieAPI/stats.db
proxy              | [2023-01-31 19:37:01 +0000] [37] [DEBUG] Closing connection. 
proxy              | [2023-01-31 19:37:02 +0000] [37] [DEBUG] GET /canarie/background.jpg
proxy              | [2023-01-31 19:37:02,176] [37] [INFO] app_object : Disconnecting from database
proxy              | [2023-01-31 19:37:02,176] [37] [DEBUG] app_object : Using db filename : /opt/local/src/CanarieAPI/stats.db
proxy              | [2023-01-31 19:37:02 +0000] [37] [ERROR] Error handling request /canarie/background.jpg
proxy              | Traceback (most recent call last):
proxy              |   File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/async.py", line 56, in handle
proxy              |     self.handle_request(listener_name, req, client, addr)
proxy              |   File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/ggevent.py", line 152, in handle_request
proxy              |     super(GeventWorker, self).handle_request(*args)
proxy              |   File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/async.py", line 107, in handle_request
proxy              |     respiter = self.wsgi(environ, resp.start_response)
proxy              |   File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1997, in __call__
proxy              |     return self.wsgi_app(environ, start_response)
proxy              |   File "/opt/local/src/CanarieAPI/canarieapi/reverse_proxied.py", line 33, in __call__
proxy              |     return self.app(environ, start_response)
proxy              |   File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1985, in wsgi_app
proxy              |     response = self.handle_exception(e)
proxy              |   File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1532, in handle_exception
proxy              |     handler = self._find_error_handler(InternalServerError())
proxy              |   File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1449, in _find_error_handler
proxy              |     .get(code))
proxy              |   File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1440, in find_handler
proxy              |     handler = handler_map.get(cls)
proxy              | AttributeError: 'function' object has no attribute 'get'
```