### PR TITLE
fix cron script executions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,11 @@ CHANGES
 `Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Fix ``canarieapi-cron`` default configuration to provide the ``PYTHONPATH`` to avoid unresolved package location
-  with ``ImportError``/``ModuleNotFoundError`` when calling the ``logparser`` and ``monitoring`` scripts.
+* Fix ``Dockerfile`` to setup ``CanarieAPI`` accessible from anywhere to avoid ``canarieapi-cron`` failure unless
+  explicit ``PYTHONPATH`` was specified. Avoids unresolved package location with ``ImportError``/``ModuleNotFoundError``
+  when calling the ``logparser`` and ``monitoring`` scripts.
+* Add ``CanarieAPI`` import validation with ``test-docker`` to ensure package is properly installed and accessible
+  from anywhere in the Docker image.
 
 `0.5.0 <https://github.com/Ouranosinc/CanarieAPI/tree/0.5.0>`_ (2023-02-15)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ CHANGES
 `Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
+* Fix ``canarieapi-cron`` default configuration to provide the ``PYTHONPATH`` to avoid unresolved package location
+  with ``ImportError``/``ModuleNotFoundError`` when calling the ``logparser`` and ``monitoring`` scripts.
+
 `0.5.0 <https://github.com/Ouranosinc/CanarieAPI/tree/0.5.0>`_ (2023-02-15)
 ------------------------------------------------------------------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
 
 # Install package
 COPY ./ ${PKG_DIR}/
-RUN pip install --no-dependencies -e ${PKG_DIR}
+RUN pip install --no-dependencies ${PKG_DIR}
 
 # cron job will inherit the current user environment
 # start cron service

--- a/canarieapi-cron
+++ b/canarieapi-cron
@@ -1,2 +1,2 @@
-* * * * * root PYTHONPATH=/opt/local/src/CanarieAPI python -c 'from canarieapi import logparser; logparser.cron_job()' >> /var/log/logparser_cron.log 2>&1
-* * * * * root PYTHONPATH=/opt/local/src/CanarieAPI python -c 'from canarieapi import monitoring; monitoring.cron_job()' >> /var/log/monitoring_cron.log 2>&1
+* * * * * root python -c 'from canarieapi import logparser; logparser.cron_job()' >> /var/log/logparser_cron.log 2>&1
+* * * * * root python -c 'from canarieapi import monitoring; monitoring.cron_job()' >> /var/log/monitoring_cron.log 2>&1

--- a/canarieapi-cron
+++ b/canarieapi-cron
@@ -1,2 +1,2 @@
-* * * * * root python -c 'from canarieapi import logparser; logparser.cron_job()' >> /var/log/logparser_cron.log 2>&1
-* * * * * root python -c 'from canarieapi import monitoring; monitoring.cron_job()' >> /var/log/monitoring_cron.log 2>&1
+* * * * * root PYTHONPATH=/opt/local/src/CanarieAPI python -c 'from canarieapi import logparser; logparser.cron_job()' >> /var/log/logparser_cron.log 2>&1
+* * * * * root PYTHONPATH=/opt/local/src/CanarieAPI python -c 'from canarieapi import monitoring; monitoring.cron_job()' >> /var/log/monitoring_cron.log 2>&1


### PR DESCRIPTION
Since 0.4.x versions, the `-e` installation flag in Docker caused the `canarieapi` package to not be available from `cron` call.
Log parsing and monitoring was silently failing and not reporting any update unless `/test` was manually invoke to generate the corresponding calls. 

Fixes the installation such that the `python` call in the `cron` command can see the package from anywhere.