### PR TITLE
stats endpoint rendered table on errors

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,7 +2,8 @@
   "extends": "stylelint-config-standard",
   "ignoreFiles": [
     "build/**",
-    "docs/_build/**"
+    "docs/_build/**",
+    "reports/**"
   ],
   "rules": {
     "block-no-empty": null,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ CHANGES
 `Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
+* Add better table formatted HTML rendering from the stats endpoints even when a monitoring error of an underlying
+  endpoint occurs to allow better readability of the cause of error.
+* Add cached database logging entry to facilitate debugging.
+
 `0.5.1 <https://github.com/Ouranosinc/CanarieAPI/tree/0.5.1>`_ (2023-02-16)
 ------------------------------------------------------------------------------------
 

--- a/canarieapi/utility_rest.py
+++ b/canarieapi/utility_rest.py
@@ -30,7 +30,22 @@ from canarieapi.app_object import APP
 
 APIType = Literal["platform", "service"]
 _JSON: TypeAlias = "JSON"
-JSON = Union[Dict[str, Union[Dict[str, _JSON], List[_JSON], _JSON, float, int, str, bool, None]], _JSON]
+JSON = Union[  # pylint: disable=C0103
+    Dict[
+        str,
+        Union[
+            Dict[str, _JSON],
+            List[_JSON],
+            _JSON,
+            float,
+            int,
+            str,
+            bool,
+            None
+        ]
+    ],
+    _JSON
+]
 
 
 def request_wants_json() -> bool:

--- a/canarieapi/utility_rest.py
+++ b/canarieapi/utility_rest.py
@@ -206,7 +206,9 @@ def get_db() -> sqlite3.Connection:
     Stores the established connection in the application's global context to reuse it whenever required.
     """
     database = getattr(g, "_database", None)
-    if database is None:
+    if database is not None:
+        APP.logger.info("Database found. Reusing cached connection...")
+    else:
         APP.logger.info("Database not defined. Establishing connection...")
 
         database_fn = APP.config["DATABASE"]["filename"]


### PR DESCRIPTION
Instead of the previously returned blob of text:
![image](https://user-images.githubusercontent.com/19194484/226984732-8366e6e9-d28a-4bd1-be7f-fb15c7c7c09e.png)

The error response will provide relevant details to help identify the issue with better readability:
![image](https://user-images.githubusercontent.com/19194484/226984126-ce290938-366d-42a9-bd3b-7f6428175ca5.png)
