### PR TITLE
add decorator to retry db operation after init to fix missing cron table if error detected

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ CHANGES
 * Add a retry function decorator for database operations to handle rare occurrences where the database could have been
   improperly initialized. In case of relevant database issue, the operation is retried after running the initialization.
 * Add more logging entries to help debug error causes and relevant database operations that lead to them if applicable.
+* Avoid unnecessary creation of a database connection simply to close it when performing teardown request cleanup.
+  This occurred at least 3 times for each HTML requests because of UI static file requests retrieved for display.
+  Also, avoids the unnecessary verbose logging of opening, finding and closing this unused database connection.
 
 `0.6.0 <https://github.com/Ouranosinc/CanarieAPI/tree/0.6.0>`_ (2023-03-22)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ CHANGES
 `Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
+* Add a retry function decorator for database operations to handle rare occurrences where the database could have been
+  improperly initialized. In case of relevant database issue, the operation is retried after running the initialization.
+* Add more logging entries to help debug error causes and relevant database operations that lead to them if applicable.
+
 `0.6.0 <https://github.com/Ouranosinc/CanarieAPI/tree/0.6.0>`_ (2023-03-22)
 ------------------------------------------------------------------------------------
 

--- a/canarieapi/api.py
+++ b/canarieapi/api.py
@@ -202,7 +202,6 @@ def information(route_name: str, api_type: APIType) -> ResponseReturnValue:
     """
     Info route required by CANARIE.
     """
-
     # JSON is used by default but the Canarie API requires html as default
     set_html_as_default_response()
 
@@ -324,7 +323,6 @@ def stats(route_name: str, api_type: APIType) -> ResponseReturnValue:
     """
     Stats route required by CANARIE.
     """
-
     # JSON is used by default but the Canarie API requires html as default
     set_html_as_default_response()
 
@@ -396,7 +394,6 @@ def status(route_name: str, api_type: APIType) -> ResponseReturnValue:
     """
     Extra route to know service status.
     """
-
     # JSON is used by default but the Canarie API requires html as default
     set_html_as_default_response()
 
@@ -440,7 +437,6 @@ def simple_requests_handler(route_name: str, api_type: APIType, api_request: str
     """
     #Handle simple requests required by CANARIE.
     """
-
     # JSON is used by default but the Canarie API requires html as default
     set_html_as_default_response()
 

--- a/canarieapi/api.py
+++ b/canarieapi/api.py
@@ -456,8 +456,10 @@ def close_connection(_: Exception) -> None:
 
     :param _: Exception handled elsewhere, nothing to do with it
     """
-    APP.logger.info(u"Disconnecting from database")
-    get_db().close()
+    db = get_db(connect=False)  # avoid creating a connection only to close it.
+    if db:
+        APP.logger.info("Disconnecting from database.")
+        db.close()
 
 
 if __name__ == "__main__":

--- a/canarieapi/api.py
+++ b/canarieapi/api.py
@@ -17,12 +17,11 @@ the CANARIE API specification.
 .. seealso::
     https://www.canarie.ca/software/support/documentation-guides/
 """
-import sqlite3
-
 # -- Standard lib ------------------------------------------------------------
 import collections
 import datetime
 import os
+import sqlite3
 from typing import Dict, Optional
 from typing_extensions import TypedDict
 
@@ -316,7 +315,7 @@ def collect_cron_last_status(*, database: Optional[sqlite3.Connection] = None) -
         APP.logger.error(str(exc))
 
     cur.close()
-    
+
     return {"last_status_update": last_status_update}
 
 
@@ -404,7 +403,6 @@ def status(route_name: str, api_type: APIType) -> ResponseReturnValue:
     validate_route(route_name, api_type)
 
     db = get_db()
-    cur = db.cursor()
 
     # Gather service(s) status
     all_status = collect_monitoring_statuses(route_name, database=db)

--- a/canarieapi/database_schema.sql
+++ b/canarieapi/database_schema.sql
@@ -1,20 +1,23 @@
-CREATE TABLE [stats] (
+CREATE TABLE IF NOT EXISTS [stats] (
   [route] VARCHAR(32),
   [invocations] INTEGER,
-  [last_access] DATETIME);
+  [last_access] DATETIME
+);
 
-CREATE UNIQUE INDEX [stats_id] ON [stats] ([route]);
+CREATE UNIQUE INDEX IF NOT EXISTS [stats_id] ON [stats] ([route]);
 
-CREATE TABLE [status] (
+CREATE TABLE IF NOT EXISTS [status] (
   [route] VARCHAR(32),
   [service] VARCHAR(32),
   [status] VARCHAR(8),
-  [message] VARCHAR(256));
+  [message] VARCHAR(256)
+);
 
-CREATE UNIQUE INDEX [status_id] ON [status] ([route], [service]);
+CREATE UNIQUE INDEX IF NOT EXISTS [status_id] ON [status] ([route], [service]);
 
-CREATE TABLE [cron] (
+CREATE TABLE IF NOT EXISTS [cron] (
   [job] VARCHAR(32),
-  [last_execution] DATETIME);
+  [last_execution] DATETIME
+);
 
-CREATE UNIQUE INDEX [cron_id] ON [cron] ([job]);
+CREATE UNIQUE INDEX IF NOT EXISTS [cron_id] ON [cron] ([job]);

--- a/canarieapi/logparser.py
+++ b/canarieapi/logparser.py
@@ -1,11 +1,10 @@
 # -- Standard lib ------------------------------------------------------------
-import sqlite3
-
 import logging
 import logging.handlers
 import os
 import re
 import signal
+import sqlite3
 import time
 from typing import Dict, Optional, Union
 

--- a/canarieapi/monitoring.py
+++ b/canarieapi/monitoring.py
@@ -1,7 +1,6 @@
 # -- Standard lib ------------------------------------------------------------
-import sqlite3
-
 import re
+import sqlite3
 from typing import Dict, Optional, Tuple, Union
 from typing_extensions import Literal, NotRequired, Required, TypedDict
 

--- a/canarieapi/utility_rest.py
+++ b/canarieapi/utility_rest.py
@@ -48,7 +48,7 @@ JSON = Union[  # pylint: disable=C0103
     _JSON
 ]
 
-ReturnType = TypeVar("ReturnType")
+ReturnType = TypeVar("ReturnType")  # pylint: disable=C0103
 
 
 def request_wants_json() -> bool:
@@ -287,7 +287,8 @@ def init_db(database: sqlite3.Connection) -> None:
 
 
 class DatabaseRetryFunction(Protocol):
-    def __call__(self, *args: Any, database: Optional[sqlite3.Connection] = None, **kwargs: Any) -> ReturnType: ...
+    def __call__(self, *args: Any, database: Optional[sqlite3.Connection] = None, **kwargs: Any) -> ReturnType:
+        ...
 
 
 def retry_db_error_after_init(func: DatabaseRetryFunction) -> DatabaseRetryFunction:

--- a/canarieapi/utility_rest.py
+++ b/canarieapi/utility_rest.py
@@ -16,8 +16,8 @@ import inspect
 import os
 import re
 import sqlite3
-from typing import Any, Dict, List, Optional, Protocol, Tuple, TypeVar, Union
-from typing_extensions import Literal, TypeAlias
+from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
+from typing_extensions import Literal, Protocol, TypeAlias
 
 # -- 3rd party ---------------------------------------------------------------
 from flask import Response, current_app, g, jsonify, redirect, render_template, request

--- a/canarieapi/utility_rest.py
+++ b/canarieapi/utility_rest.py
@@ -214,7 +214,7 @@ def make_error_response(
     return template, http_status
 
 
-def get_db() -> sqlite3.Connection:
+def get_db(allow_cache: bool = True, connect: bool = True) -> sqlite3.Connection:
     """
     Get a connection to an existing database.
 
@@ -224,9 +224,9 @@ def get_db() -> sqlite3.Connection:
     Stores the established connection in the application's global context to reuse it whenever required.
     """
     database = getattr(g, "_database", None)
-    if database is not None:
+    if database is not None and allow_cache:
         APP.logger.info("Database found. Reusing cached connection...")
-    else:
+    elif connect:
         APP.logger.info("Database not defined. Establishing connection...")
 
         database_fn = APP.config["DATABASE"]["filename"]

--- a/canarieapi/utility_rest.py
+++ b/canarieapi/utility_rest.py
@@ -58,7 +58,6 @@ def request_wants_json() -> bool:
     The default Media-Type ``*/*`` will be interpreted as JSON.
     Omitting a preferred type entirely will also default to JSON.
     """
-
     # Best will be JSON if it's in accepted mimetypes and has a quality greater or equal to HTML.
     # For */* both JSON and HTML will have the same quality so JSON still win.
     # Unspecified type is usually the case for scripts (requests, curl, etc.).
@@ -83,7 +82,6 @@ def set_html_as_default_response() -> None:
     This is useful for automatically rendering HTML by web browsers that do not
     provide explicitly the desired mimetype.
     """
-
     # Best will be HTML if it's in accept mimetypes and
     # has a quality greater or equal to JSON.
     # For */* both JSON and HTML will have the same quality so HTML still wins
@@ -135,7 +133,6 @@ def get_api_title(route_name: str, api_type: APIType) -> str:
     :param api_type: Api type of the route which must be one of platform or service
     :returns: An API title
     """
-
     title = api_type.capitalize()
     try:
         name = get_config(route_name, api_type)["info"]["name"]
@@ -155,7 +152,6 @@ def get_canarie_api_response(route_name: str, api_type: APIType, api_request: st
     :param api_request: The request specified in the URL
     :returns: A valid HTML response
     """
-
     # Factsheet is not part of the service API, so it's expected that the config will not be found
     if api_type == "service" and api_request == "factsheet":
         return make_error_response(http_status=404)
@@ -295,7 +291,6 @@ def retry_db_error_after_init(func: DatabaseRetryFunction) -> DatabaseRetryFunct
     """
     Decorator that will retry a failing operation if an error related to database initialization occurred.
     """
-
     @functools.wraps(func)
     def retry(*args: Any, database: sqlite3.Connection = None, **kwargs: Any) -> ReturnType:
         db_param = inspect.signature(func).parameters.get("database")

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,9 @@ search =
 replace = 
 	`Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
 	------------------------------------------------------------------------------------
+
+	.. **ADD LIST ITEMS WITH NEW CHANGES AND REMOVE THIS COMMENT**
+	No changes yet.
 	
 	`{new_version} <https://github.com/Ouranosinc/CanarieAPI/tree/{new_version}>`_ ({now:%%Y-%%m-%%d})
 	------------------------------------------------------------------------------------

--- a/tests/test_canarieapi.py
+++ b/tests/test_canarieapi.py
@@ -25,6 +25,7 @@ class TestCanarieAPI(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.config = test_config
+        os.makedirs(cls.config.db_dir, exist_ok=True)
 
         # important not to import APP at the top nor before config/env were applied
         # otherwise, configuration is loaded immediately and raises an error due to missing directory to store DB file
@@ -203,6 +204,7 @@ class TestDatabaseErrorHandling(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.config = test_config
+        os.makedirs(cls.config.db_dir, exist_ok=True)
 
         # important not to import APP at the top nor before config/env were applied
         # otherwise, configuration is loaded immediately and raises an error due to missing directory to store DB file

--- a/tests/test_canarieapi.py
+++ b/tests/test_canarieapi.py
@@ -14,6 +14,7 @@ from flask_webtest import TestApp
 
 from canarieapi.logparser import cron_job as cron_job_logparse
 from canarieapi.monitoring import cron_job as cron_job_monitor
+from canarieapi.utility_rest import get_db, init_db
 from tests import config as test_config
 
 
@@ -193,6 +194,76 @@ class TestCanarieAPI(unittest.TestCase):
         resp = self.web.get(f"/{name}/service/doc", params={"f": "json"})
         assert resp.status_code == 302, "Expect redirect request to the service's doc redirect endpoint"
         assert resp.location == f"{url.rstrip('/')}/doc"
+
+
+class TestDatabaseErrorHandling(unittest.TestCase):
+    app = None
+    config = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.config = test_config
+
+        # important not to import APP at the top nor before config/env were applied
+        # otherwise, configuration is loaded immediately and raises an error due to missing directory to store DB file
+        cfg_path = os.path.abspath(test_config.__file__)
+        try:
+            with mock.patch.dict("os.environ",
+                                 {"CANARIE_API_CONFIG_FN": cfg_path, "CANARIE_API_SKIP_CHECK": "true"}):
+                from canarieapi.api import APP  # isort: skip  # noqa
+        except ImportError:
+            print(f"Failed loading APP with test config. Ensure [CANARIE_API_CONFIG_FN={cfg_path}] is set!")
+            raise
+
+        APP.config.from_object(cls.config)
+
+        # setup monitored apps
+        for i, (_, cfg) in enumerate(APP.config["SERVICES"].items()):
+            port = 6000 + i
+            url = f"http://localhost:{port}/"
+            cfg["monitoring"]["Component"]["request"]["url"] = url
+            responses.get(url, json={}, status=200)  # mock their response
+            for req in cfg["redirect"]:
+                cfg["redirect"][req] = f"{url.rstrip('/')}/{req}"  # not called, just set for compare
+
+        cls.app = APP
+        cls.web = TestApp(cls.app)
+
+        responses.start()  # mock for monitors
+
+    def setUp(self) -> None:
+        # trigger cron updates immediately to generate status update entries
+        # these should end up calling the above monitored apps
+        cron_job_logparse()
+        cron_job_monitor()
+
+    @classmethod
+    def tearDownClass(cls):
+        path = cls.app.config.get("DATABASE", {}).get("filename", "")
+        dir_path = os.path.dirname(path)
+        if path and os.path.isdir(dir_path) and "tmp" in os.path.basename(dir_path):
+            shutil.rmtree(dir_path)
+
+    def test_database_handled_init_retry_from_error(self):
+        # simulate an invalid database definition
+        with self.app.app_context():
+            db = get_db()
+            cur = db.cursor()
+            cur.execute("DROP TABLE cron")
+            db.commit()
+            cur.close()
+
+        # perform a request that will lead to a database operation that needs the missing table
+        with mock.patch("canarieapi.utility_rest.init_db", side_effect=init_db) as mock_init_db:
+            assert mock_init_db.call_count == 0
+            resp = self.web.get("/test", params={"f": "json"})
+            while 300 < resp.status_code < 310:
+                resp = resp.follow()
+            assert resp.status_code == 200
+            assert "Platforms" in resp.json
+            assert "Services" in resp.json
+            assert all(svc in resp.json["Services"] for svc in self.app.config["SERVICES"])
+            assert mock_init_db.call_count == 1
 
 
 if __name__ == "__main__":

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -22,7 +22,6 @@ def test_validate_error_wrong_schema(tmp_config):  # noqa  # pylint: disable=W06
     """
     Ensure the configuration schema is used to validate the application configuration at startup.
     """
-
     from canarieapi.api import APP  # isort: skip  # noqa
 
     APP.config.update({


### PR DESCRIPTION

## Changes

* Add a retry function decorator for database operations to handle rare occurrences where the database could have been
  improperly initialized. In case of relevant database issue, the operation is retried after running the initialization.
* Add more logging entries to help debug error causes and relevant database operations that lead to them if applicable.
* Avoid unnecessary creation of a database connection simply to close it when performing teardown request cleanup.
  This occurred at least 3 times for each HTML requests because of UI static file requests retrieved for display.
  Also, avoids the unnecessary verbose logging of opening, finding and closing this unused database connection.

## References

- Resolve issue identified in https://github.com/bird-house/birdhouse-deploy/pull/284#issuecomment-1507142084