### PR TITLE
drop python 3.7 support + add python 3.12 support + fix werkzeug security

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, windows-latest]
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         allow-failure: [false]
         test-case: [test]
         # can use below option to set environment variables or makefile settings applied during test execution

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,9 @@
 # configuration to setup readthedocs
 version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
 sphinx:
   configuration: docs/conf.py
 # note:
@@ -11,7 +15,6 @@ formats:
   #- pdf
   #- epub
 python:
-  version: "3.8"
   install:
     - requirements: requirements-doc.txt
     # required for OpenAPI generation
@@ -20,5 +23,3 @@ python:
 #      path: .
 #      extra_requirements:
 #        - docs
-  system_packages: true
-

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,13 @@ CHANGES
 `Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-.. **ADD LIST ITEMS WITH NEW CHANGES AND REMOVE THIS COMMENT**
-
-* No changes yet.
+* Add support of Python 3.12.
+* Drop support of Python 3.7.
+* Fix security issue for ``werkzeug`` (fixes
+  `#27 <https://github.com/Ouranosinc/CanarieAPI/pull/27>`_,
+  `#28 <https://github.com/Ouranosinc/CanarieAPI/pull/28>`_,
+  `#29 <https://github.com/Ouranosinc/CanarieAPI/pull/29>`_,
+  `#30 <https://github.com/Ouranosinc/CanarieAPI/pull/30>`_).
 
 `1.0.0 <https://github.com/Ouranosinc/CanarieAPI/tree/1.0.0>`_ (2023-08-29)
 ------------------------------------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,6 @@ from canarieapi import __meta__  # isort: skip  # noqa  # pylint: disable=C0413
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",  # help make cross-references to title/sections
-    "cloud_sptheme.ext.autodoc_sections",  # allow sections in docstrings code
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ flake8-quotes
 flask_webtest
 isort>5.5
 mock
-pylint>=2.11,!=2.12,!=2.15
+pylint>=2.11,!=2.12,!=2.15,<3
 pylint-flask
 pylint-quotes
 pytest

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -2,10 +2,9 @@
 # we actually need to install all requirements during docs build because of OpenAPI generation
 # (see 'docs/conf.py')
 astroid
-cloud_sptheme
-jinja2<3.1  # fix sphinx failing with cloud_sptheme, see: https://github.com/sphinx-doc/sphinx/issues/10291
+jinja2
 pycodestyle>=2.6.0,<3
-sphinx>=5.0,<6
+sphinx>=6,<7
 sphinx-autoapi>=1.7.0
 sphinx-autodoc-typehints
 sphinx-paramlinks>=0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ setuptools>=65.5.1
 typing_extensions
 watchdog==0.8.3
 wheel>=0.37.1
+werkzeug>=3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask>=2.2
+flask>=3
 gevent
 gunicorn
 jsonschema
@@ -6,6 +6,5 @@ python-dateutil
 requests>=2.20.0
 setuptools>=65.5.1
 typing_extensions
-watchdog==0.8.3
 wheel>=0.37.1
 werkzeug>=3.0.1

--- a/setup.py
+++ b/setup.py
@@ -202,7 +202,7 @@ setup(
     platforms=["linux_x86_64"],
     license="ISCL",
     keywords="CanarieAPI",
-    python_requires=">=3.7,<4",
+    python_requires=">=3.8,<4",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -211,11 +211,11 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 
     # -- Package structure -------------------------------------------------


### PR DESCRIPTION
* Add support of Python 3.12.
* Drop support of Python 3.7.
* Fix security issue for ``werkzeug``

* closes #27 
* closes #28
* closes #29 
* closes #30 