### PR TITLE
fix parsing and extraction of time-zone aware datetime between logs and db

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -414,7 +414,7 @@ function-naming-style=snake_case
 #function-rgx=
 
 # Good variable names which should always be accepted, separated by a comma.
-good-names=i,j,k,v,kv,ex,fn,x,y,z,f,fd,h,db,kw,ns,qs,_
+good-names=i,j,k,v,kv,ex,fn,x,y,z,f,fd,h,db,dt,kw,ns,qs,_
 
 # Include a hint for the correct naming format with invalid-name.
 include-naming-hint=yes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ CHANGES
 `Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
+* Bump Docker base image to Python 3.12.
 * Fix time-zone aware datetime parsing for log/db entries comparison
   (fixes `#21 <https://github.com/Ouranosinc/CanarieAPI/issues/21>`_).
 * Fix multiple log record lookup doing an additional index leading to invalid DB extraction,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,9 @@ CHANGES
 `Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-.. **ADD LIST ITEMS WITH NEW CHANGES AND REMOVE THIS COMMENT**
-
-* No changes yet.
+* Fix time-zone aware datetime parsing for log/db entries comparison
+  (fixes `#21 <https://github.com/Ouranosinc/CanarieAPI/issues/21>`_).
+* Fix log record doing an additional index leading to invalid DB datetime extraction.
 
 `1.0.2 <https://github.com/Ouranosinc/CanarieAPI/tree/1.0.2>`_ (2025-09-04)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,8 @@ CHANGES
 
 * Fix time-zone aware datetime parsing for log/db entries comparison
   (fixes `#21 <https://github.com/Ouranosinc/CanarieAPI/issues/21>`_).
-* Fix log record doing an additional index leading to invalid DB datetime extraction.
+* Fix multiple log record lookup doing an additional index leading to invalid DB extraction,
+  of datetime, last update status, and invocation counts.
 * Fix ``ReadTimeout`` not handled as ``ConnectionError`` during service check.
 
 `1.0.2 <https://github.com/Ouranosinc/CanarieAPI/tree/1.0.2>`_ (2025-09-04)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ CHANGES
 * Fix time-zone aware datetime parsing for log/db entries comparison
   (fixes `#21 <https://github.com/Ouranosinc/CanarieAPI/issues/21>`_).
 * Fix log record doing an additional index leading to invalid DB datetime extraction.
+* Fix ``ReadTimeout`` not handled as ``ConnectionError`` during service check.
 
 `1.0.2 <https://github.com/Ouranosinc/CanarieAPI/tree/1.0.2>`_ (2025-09-04)
 ------------------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.12
 LABEL description="CanarieAPI: Self describing REST service for Canarie registry."
 LABEL maintainer="David Byrns <david.byrns@crim.ca>, Francis Charette-Migneault <francis.charette-migneault@crim.ca>"
 LABEL vendor="Ouranosinc, CRIM"

--- a/canarieapi/api.py
+++ b/canarieapi/api.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding:utf-8
 
-# N.B. : Some of these docstrings are written in reSTructuredText format so that
+# N.B. : Some of these docstrings are written in reStructuredText format so that
 # Sphinx can use them directly with fancy formatting.
 
 # In the context of a REST application, this module must be loaded first as it
@@ -260,10 +260,10 @@ def collect_cron_access_stats(route_name: str, *, database: Optional[sqlite3.Con
     cur = db.cursor()
     try:
         cur.execute(query, [route_name])
-        records = cur.fetchone()
-        if records:
-            invocations = records[0][0]
-            last_access = dt_parse(records[0][1]).replace(tzinfo=None).isoformat() + "Z"
+        record = cur.fetchone()
+        if record:
+            invocations = record[0]
+            last_access = dt_parse(record[1]).replace(tzinfo=None).isoformat() + "Z"
     except Exception as exc:  # pragma: no cover
         APP.logger.error(str(exc))
 
@@ -306,9 +306,9 @@ def collect_cron_last_status(*, database: Optional[sqlite3.Connection] = None) -
     cur = db.cursor()
     try:
         cur.execute(query)
-        records = cur.fetchone()
-        if records:
-            last_status_update = dt_parse(records[0][0]).isoformat() + "Z"
+        record = cur.fetchone()
+        if record:
+            last_status_update = dt_parse(record[0]).isoformat() + "Z"
     except Exception as exc:  # pragma: no cover
         APP.logger.error(str(exc))
 

--- a/canarieapi/logparser.py
+++ b/canarieapi/logparser.py
@@ -1,6 +1,7 @@
 # -- Standard lib ------------------------------------------------------------
 import re
 import sqlite3
+from datetime import datetime, timezone
 from typing import Dict, Optional, Union
 
 # -- 3rd party ---------------------------------------------------------------
@@ -11,6 +12,16 @@ from canarieapi.app_object import APP
 from canarieapi.utility_rest import get_db, retry_db_error_after_init
 
 RouteStatistics = Dict[str, Dict[str, Union[str, int]]]
+
+
+def parse_datetime(dt_str: str) -> datetime:
+    """
+    Parse datetime string from log and return it with TimeZone awareness.
+    """
+    dt = dt_parse(dt_str)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
 
 
 def parse_log(filename: str, database: Optional[sqlite3.Connection] = None) -> RouteStatistics:
@@ -44,7 +55,7 @@ def parse_log(filename: str, database: Optional[sqlite3.Connection] = None) -> R
         cur.execute("select last_access from stats order by last_access desc limit 1")
         records = cur.fetchone()
         if records:
-            last_access = dt_parse(records[0][0])
+            last_access = parse_datetime(records[0])
         else:
             last_access = None
 
@@ -57,7 +68,7 @@ def parse_log(filename: str, database: Optional[sqlite3.Connection] = None) -> R
             match = log_regex.match(line)
             if match:
                 records = match.groupdict()
-                if last_access is None or dt_parse(records["datetime"]) > last_access:
+                if last_access is None or parse_datetime(records["datetime"]) > last_access:
                     log_records.append(records)
 
     # Compile stats

--- a/canarieapi/logparser.py
+++ b/canarieapi/logparser.py
@@ -75,8 +75,7 @@ def parse_log(filename: str, database: Optional[sqlite3.Connection] = None) -> R
     logger.info("Compiling stats from %s records", len(log_records))
     for record in log_records:
         for route, value in route_stats.items():
-            if value["route_regex"].match(record["route"]) and \
-               value["method_regex"].match(record["method"]):
+            if value["route_regex"].match(record["route"]) and value["method_regex"].match(record["method"]):
                 value["count"] = value["count"] + 1
                 value["last_access"] = record["datetime"]
                 break

--- a/canarieapi/monitoring.py
+++ b/canarieapi/monitoring.py
@@ -6,7 +6,7 @@ from typing_extensions import Literal, NotRequired, Required, TypedDict
 
 # -- 3rd party modules -------------------------------------------------------
 import requests
-from requests.exceptions import ConnectionError  # pylint: disable=W0622
+from requests.exceptions import ConnectionError, Timeout  # pylint: disable=W0622
 
 # -- Project specific --------------------------------------------------------
 from canarieapi.app_object import APP
@@ -97,7 +97,7 @@ def check_service(request: RequestConfig, response: ResponseConfig) -> Tuple[Sta
     logger = APP.logger
     try:
         resp = requests.request(**default_request)
-    except ConnectionError as exc:
+    except (ConnectionError, Timeout) as exc:
         url = default_request["url"]
         message = f"Cannot reach {url} : {exc!s}"
         logger.warning(message)

--- a/setup.cfg
+++ b/setup.cfg
@@ -138,7 +138,7 @@ markers =
 	auth_admin: magpie operations that require admin-level access
 	auth_users: magpie operations that require user-level access (non admin)
 	auth_public: magpie operations that are publicly accessible (no auth)
-tmp_path_retention_policy = "none"
+tmp_path_retention_policy = none
 
 [wheel]
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -138,6 +138,7 @@ markers =
 	auth_admin: magpie operations that require admin-level access
 	auth_users: magpie operations that require user-level access (non admin)
 	auth_public: magpie operations that are publicly accessible (no auth)
+tmp_path_retention_policy = "none"
 
 [wheel]
 universal = 1

--- a/tests/config.py
+++ b/tests/config.py
@@ -19,6 +19,7 @@ SERVICES.update({
 })
 for name, svc in SERVICES.items():
     svc["info"]["name"] = name
+    svc["stats"]["route"] = f"/{name}/.*"
 
 # avoid errors triggered by sample config during tests
 PLATFORMS.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+
 import pytest
 
 from tests import config as test_config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import os
+import shutil
+import pytest
+
+from tests import config as test_config
+
+
+@pytest.fixture()
+def tmp_config():
+    from canarieapi.api import APP
+
+    APP.config.from_object(test_config)
+
+    yield
+
+    tmp_dir = os.path.dirname(test_config.DATABASE["filename"])
+    if "tmp" in tmp_dir and os.path.isdir(tmp_dir):
+        shutil.rmtree(tmp_dir)

--- a/tests/test_canarieapi.py
+++ b/tests/test_canarieapi.py
@@ -57,7 +57,7 @@ class TestCanarieAPI(unittest.TestCase):
     def setUp(self) -> None:
         # trigger cron updates immediately to generate status update entries
         # these should end up calling the above monitored apps
-        os.makedirs(os.path.basename(self.config.DATABASE["access_log"]), exist_ok=True)
+        os.makedirs(os.path.dirname(self.config.DATABASE["access_log"]), exist_ok=True)
         with open(self.config.DATABASE["access_log"], mode="w", encoding="utf-8") as f:
             # create a new empty access log before each test
             # file must exist but the content doesn't matter for these tests)
@@ -262,7 +262,7 @@ class TestDatabaseErrorHandling(unittest.TestCase):
     def setUp(self) -> None:
         # trigger cron updates immediately to generate status update entries
         # these should end up calling the above monitored apps
-        os.makedirs(os.path.basename(self.config.DATABASE["access_log"]), exist_ok=True)
+        os.makedirs(os.path.dirname(self.config.DATABASE["access_log"]), exist_ok=True)
         with open(self.config.DATABASE["access_log"], mode="w", encoding="utf-8") as f:
             # create a new empty access log before each test
             # file must exist but the content doesn't matter for these tests)

--- a/tests/test_canarieapi.py
+++ b/tests/test_canarieapi.py
@@ -55,10 +55,10 @@ class TestCanarieAPI(unittest.TestCase):
     def setUp(self) -> None:
         # trigger cron updates immediately to generate status update entries
         # these should end up calling the above monitored apps
-        with open(self.config.DATABASE["access_log"], "w", encoding="utf-8"):
+        with open(self.config.DATABASE["access_log"], "w", encoding="utf-8") as f:
             # create a new empty access log before each test
             # file must exist but the content doesn't matter for these tests)
-            pass
+            os.utime(f.name, None)
         cron_job_logparse()
         cron_job_monitor()
 
@@ -239,10 +239,10 @@ class TestDatabaseErrorHandling(unittest.TestCase):
     def setUp(self) -> None:
         # trigger cron updates immediately to generate status update entries
         # these should end up calling the above monitored apps
-        with open(self.config.DATABASE["access_log"], "w", encoding="utf-8"):
+        with open(self.config.DATABASE["access_log"], "w", encoding="utf-8") as f:
             # create a new empty access log before each test
             # file must exist but the content doesn't matter for these tests)
-            pass
+            os.utime(f.name, None)
         cron_job_logparse()
         cron_job_monitor()
 

--- a/tests/test_canarieapi.py
+++ b/tests/test_canarieapi.py
@@ -6,9 +6,11 @@ Tests for `canarieapi` module.
 import os
 import shutil
 import unittest
+from datetime import datetime, timezone
 
 import mock
 import responses
+from dateutil.parser import isoparse
 from flask_webtest import TestApp
 
 from canarieapi.logparser import cron_job as cron_job_logparse
@@ -150,12 +152,32 @@ class TestCanarieAPI(unittest.TestCase):
 
     def test_service_stats_json_service_success(self):
         name = list(self.app.config["SERVICES"])[0]
+        log_path = self.config.DATABASE["access_log"]
+
+        # setup log with some access entries
+        dt1 = datetime(2025, 9, 19, 12, 0, 0, tzinfo=timezone.utc)
+        dt2 = datetime(2025, 9, 19, 13, 0, 0)  # naive
+        with open(log_path, "w", encoding="utf-8") as f:
+            f.write(f"[{dt1.isoformat()}] \"GET /{name}/test HTTP/1.1\" 200 1234\n")
+            f.write(f"[{dt2.isoformat()}] \"GET /{name}/test HTTP/1.1\" 200 1234\n")
+        cron_job_logparse()
+
+        # test status
         resp = self.web.get(f"/{name}/service/stats", params={"f": "json"})
         assert resp.status_code == 200
         assert all(
             field in resp.json
             for field in ["invocations", "lastReset", "monitoring"]
         )
+
+        # validate results
+        assert resp.json["invocations"] == 2
+        last_access = resp.json["monitoring"].get("lastAccess")
+        assert last_access != "Never"
+        try:
+            isoparse(last_access)
+        except Exception:
+            assert False, f"lastAccess is not a valid datetime: {last_access}"
 
     def test_service_stats_page_service_error(self):
         name = list(self.app.config["SERVICES"])[0]

--- a/tests/test_canarieapi.py
+++ b/tests/test_canarieapi.py
@@ -57,7 +57,8 @@ class TestCanarieAPI(unittest.TestCase):
     def setUp(self) -> None:
         # trigger cron updates immediately to generate status update entries
         # these should end up calling the above monitored apps
-        with open(self.config.DATABASE["access_log"], "w", encoding="utf-8") as f:
+        os.makedirs(os.path.basename(self.config.DATABASE["access_log"]), exist_ok=True)
+        with open(self.config.DATABASE["access_log"], mode="w", encoding="utf-8") as f:
             # create a new empty access log before each test
             # file must exist but the content doesn't matter for these tests)
             os.utime(f.name, None)
@@ -261,7 +262,8 @@ class TestDatabaseErrorHandling(unittest.TestCase):
     def setUp(self) -> None:
         # trigger cron updates immediately to generate status update entries
         # these should end up calling the above monitored apps
-        with open(self.config.DATABASE["access_log"], "w", encoding="utf-8") as f:
+        os.makedirs(os.path.basename(self.config.DATABASE["access_log"]), exist_ok=True)
+        with open(self.config.DATABASE["access_log"], mode="w", encoding="utf-8") as f:
             # create a new empty access log before each test
             # file must exist but the content doesn't matter for these tests)
             os.utime(f.name, None)

--- a/tests/test_logparser.py
+++ b/tests/test_logparser.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sqlite3
+
+from canarieapi.utility_rest import init_db
+from canarieapi.logparser import parse_log
+
+
+class DummyLogger:
+    def info(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+
+def test_parse_log_datetime_tz(tmp_path, tmp_config):
+    from canarieapi.api import APP
+
+    db_path = tmp_path / "test.db"
+    APP.config.update({
+        "SERVICES": {
+            "test-service": {"stats": {"method": "GET", "route": "/api/.*"}},
+            "other-service": {"stats": {"method": "POST", "route": "/api/other"}},
+        },
+        "PLATFORMS": {},
+        "DATABASE": {
+            "filename": str(db_path),
+            "access_log": str(tmp_path / "access.log"),
+        },
+    })
+    APP.logger = DummyLogger()
+
+    with APP.app_context():
+        conn = sqlite3.connect(db_path)
+        init_db(conn)
+        conn.execute("INSERT INTO stats (last_access) VALUES (?)", ("2023-09-18T12:00:00",))
+        conn.commit()
+
+    # Create a log file with a mix of tz-aware and tz-naive datetimes for both services
+    log_content = "".join([
+        '[2023-09-18T13:00:00+00:00] "GET /api/test HTTP/1.1" 200 1234\n',  # tz-aware, test-service
+        '[2023-09-18T14:00:00] "GET /api/test HTTP/1.1" 200 1234\n',         # tz-naive, test-service
+        '[2023-09-18T15:00:00+00:00] "POST /api/other HTTP/1.1" 200 5678\n', # tz-aware, other-service
+        '[2023-09-18T16:00:00] "POST /api/other HTTP/1.1" 200 5678\n',        # tz-naive, other-service
+        '[2023-09-18T17:00:00+00:00] "GET /api/test HTTP/1.1" 200 1234\n',   # tz-aware, test-service (latest)
+        '[2023-09-18T18:00:00] "POST /api/other HTTP/1.1" 200 5678\n',        # tz-naive, other-service (latest)
+    ])
+    log_file = tmp_path / "access.log"
+    log_file.write_text(log_content)
+
+    # Run parse_log and check that the log entries are counted for both services
+    stats = parse_log(str(log_file), database=conn)
+    assert stats["test-service"]["count"] == 3
+    assert stats["test-service"]["last_access"] == "2023-09-18T17:00:00+00:00"
+    assert stats["other-service"]["count"] == 3
+    assert stats["other-service"]["last_access"] == "2023-09-18T18:00:00"
+
+    conn.close()
+    os.remove(db_path)
+    os.remove(log_file)

--- a/tests/test_logparser.py
+++ b/tests/test_logparser.py
@@ -4,8 +4,8 @@
 import os
 import sqlite3
 
-from canarieapi.utility_rest import init_db
 from canarieapi.logparser import parse_log
+from canarieapi.utility_rest import init_db
 
 
 class DummyLogger:
@@ -44,12 +44,12 @@ def test_parse_log_datetime_tz(tmp_path, tmp_config):
 
     # Create a log file with a mix of tz-aware and tz-naive datetimes for both services
     log_content = "".join([
-        '[2023-09-18T13:00:00+00:00] "GET /api/test HTTP/1.1" 200 1234\n',  # tz-aware, test-service
-        '[2023-09-18T14:00:00] "GET /api/test HTTP/1.1" 200 1234\n',         # tz-naive, test-service
-        '[2023-09-18T15:00:00+00:00] "POST /api/other HTTP/1.1" 200 5678\n', # tz-aware, other-service
-        '[2023-09-18T16:00:00] "POST /api/other HTTP/1.1" 200 5678\n',        # tz-naive, other-service
-        '[2023-09-18T17:00:00+00:00] "GET /api/test HTTP/1.1" 200 1234\n',   # tz-aware, test-service (latest)
-        '[2023-09-18T18:00:00] "POST /api/other HTTP/1.1" 200 5678\n',        # tz-naive, other-service (latest)
+        "[2023-09-18T13:00:00+00:00] \"GET /api/test HTTP/1.1\" 200 1234\n",    # tz-aware, test-service
+        "[2023-09-18T14:00:00] \"GET /api/test HTTP/1.1\" 200 1234\n",          # tz-naive, test-service
+        "[2023-09-18T15:00:00+00:00] \"POST /api/other HTTP/1.1\" 200 5678\n",  # tz-aware, other-service
+        "[2023-09-18T16:00:00] \"POST /api/other HTTP/1.1\" 200 5678\n",        # tz-naive, other-service
+        "[2023-09-18T17:00:00+00:00] \"GET /api/test HTTP/1.1\" 200 1234\n",    # tz-aware, test-service (latest)
+        "[2023-09-18T18:00:00] \"POST /api/other HTTP/1.1\" 200 5678\n",        # tz-naive, other-service (latest)
     ])
     log_file = tmp_path / "access.log"
     log_file.write_text(log_content)

--- a/tests/test_logparser.py
+++ b/tests/test_logparser.py
@@ -36,12 +36,6 @@ def test_parse_log_datetime_tz(tmp_path, tmp_config):
     })
     APP.logger = DummyLogger()
 
-    with APP.app_context():
-        conn = sqlite3.connect(db_path)
-        init_db(conn)
-        conn.execute("INSERT INTO stats (last_access) VALUES (?)", ("2023-09-18T12:00:00",))
-        conn.commit()
-
     # Create a log file with a mix of tz-aware and tz-naive datetimes for both services
     log_content = "".join([
         "[2023-09-18T13:00:00+00:00] \"GET /api/test HTTP/1.1\" 200 1234\n",    # tz-aware, test-service
@@ -54,13 +48,18 @@ def test_parse_log_datetime_tz(tmp_path, tmp_config):
     log_file = tmp_path / "access.log"
     log_file.write_text(log_content)
 
+    try:
+        with APP.app_context():
+            conn = sqlite3.connect(db_path)
+            init_db(conn)
+            conn.execute("INSERT INTO stats (last_access) VALUES (?)", ("2023-09-18T12:00:00",))
+            conn.commit()
+        stats = parse_log(str(log_file), database=conn)
+    finally:
+        conn.close()
+
     # Run parse_log and check that the log entries are counted for both services
-    stats = parse_log(str(log_file), database=conn)
     assert stats["test-service"]["count"] == 3
     assert stats["test-service"]["last_access"] == "2023-09-18T17:00:00+00:00"
     assert stats["other-service"]["count"] == 3
     assert stats["other-service"]["last_access"] == "2023-09-18T18:00:00"
-
-    conn.close()
-    os.remove(db_path)
-    os.remove(log_file)

--- a/tests/test_logparser.py
+++ b/tests/test_logparser.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
 import sqlite3
 
 from canarieapi.logparser import parse_log

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,27 +1,11 @@
-import os
-import shutil
 
 import jsonschema
 import pytest
 
 from canarieapi.schema import validate_config_schema
-from tests import config as test_config
 
 
-@pytest.fixture(autouse=True)
-def tmp_config():
-    from canarieapi.api import APP
-
-    APP.config.from_object(test_config)
-
-    yield
-
-    tmp_dir = os.path.dirname(test_config.DATABASE["filename"])
-    if "tmp" in tmp_dir and os.path.isdir(tmp_dir):
-        shutil.rmtree(tmp_dir)
-
-
-def test_validate_error_wrong_schema():
+def test_validate_error_wrong_schema(tmp_config):
     """
     Ensure the configuration schema is used to validate the application configuration at startup.
     """
@@ -36,7 +20,7 @@ def test_validate_error_wrong_schema():
         validate_config_schema(False, run_jobs=False)
 
 
-def test_validate_schema_no_parse_logs():
+def test_validate_schema_no_parse_logs(tmp_config):
     """
     Ensure the configuration schema is valid when PARSE_LOGS is False and stats are not set.
     """


### PR DESCRIPTION
## Changes

* Bump Docker base image to Python 3.12.
* Fix time-zone aware datetime parsing for log/db entries comparison
* Fix multiple log record lookup doing an additional index leading to invalid DB extraction, of datetime, last update status, and invocation counts.
* Fix ``ReadTimeout`` not handled as ``ConnectionError`` during service check.

## Related

- fixes #21