### PR TITLE
update docker `` python:3.12-slim``  + CMD JSON exec form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,8 @@ CHANGES
 `Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-.. **ADD LIST ITEMS WITH NEW CHANGES AND REMOVE THIS COMMENT**
-
-* No changes yet.
+* Replace Docker image to ``python:3.12-slim``.
+* Update Docker ``CMD`` with JSON execution form.
 
 `1.0.3 <https://github.com/Ouranosinc/CanarieAPI/tree/1.0.3>`_ (2025-09-22)
 ------------------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.12-slim
 LABEL description="CanarieAPI: Self describing REST service for Canarie registry."
 LABEL maintainer="David Byrns <david.byrns@crim.ca>, Francis Charette-Migneault <francis.charette-migneault@crim.ca>"
 LABEL vendor="Ouranosinc, CRIM"
@@ -28,10 +28,12 @@ COPY ./ ${PKG_DIR}/
 RUN pip install --no-dependencies ${PKG_DIR}
 
 # start gunicorn
-CMD gunicorn \
-    -b 0.0.0.0:2000 \
-    --workers 1 \
-    --log-level=DEBUG \
-    --timeout 30 \
-    -k gevent \
-    canarieapi.wsgi
+CMD [ \
+    "gunicorn", \
+    "-b", "0.0.0.0:2000", \
+    "--workers", "1", \
+    "--log-level", "DEBUG", \
+    "--timeout", "30", \
+    "-k", "gevent", \
+    "canarieapi.wsgi" \
+]


### PR DESCRIPTION
- reduce image size >50% (~1.22GB -> 560MB)
- rebuild for security fixes