### PR TITLE
Update CI and re-enable gitleaks

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,0 +1,34 @@
+[tool.bumpversion]
+current_version = "1.2.0"
+commit = true
+tag = true
+tag_name = "{new_version}"
+
+[[tool.bumpversion.files]]
+filename = "canarieapi/__meta__.py"
+search = "__version__ = \"{current_version}\""
+replace = "__version__ = \"{new_version}\""
+
+[[tool.bumpversion.files]]
+filename = "Dockerfile"
+search = "LABEL version=\"{current_version}\""
+replace = "LABEL version=\"{new_version}\""
+
+[[tool.bumpversion.files]]
+filename = "Makefile"
+search = "APP_VERSION ?= {current_version}"
+replace = "APP_VERSION ?= {new_version}"
+
+[[tool.bumpversion.files]]
+filename = "CHANGES.rst"
+search = """`Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
+------------------------------------------------------------------------------------"""
+replace = """`Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
+------------------------------------------------------------------------------------
+
+.. **ADD LIST ITEMS WITH NEW CHANGES AND REMOVE THIS COMMENT**
+
+* No changes yet.
+
+`{new_version} <https://github.com/Ouranosinc/CanarieAPI/tree/{new_version}>`_ ({now:%%Y-%%m-%%d})
+------------------------------------------------------------------------------------"""

--- a/.github/.gitleaks.toml
+++ b/.github/.gitleaks.toml
@@ -2,54 +2,67 @@
 #   https://raw.githubusercontent.com/zricethezav/gitleaks-action/master/.gitleaks.toml
 title = "gitleaks config"
 [[rules]]
+	id = "aws-id"
 	description = "AWS Manager ID"
 	regex = '''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
 	tags = ["key", "AWS"]
 [[rules]]
+	id = "aws-secret"
 	description = "AWS Secret Key"
 	regex = '''(?i)aws(.{0,20})?(?-i)['\"][0-9a-zA-Z\/+]{40}['\"]'''
 	tags = ["key", "AWS"]
 [[rules]]
+	id = "aws-mws"
 	description = "AWS MWS key"
 	regex = '''amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'''
 	tags = ["key", "AWS", "MWS"]
 [[rules]]
+	id = "facebook-secret"
 	description = "Facebook Secret Key"
 	regex = '''(?i)(facebook|fb)(.{0,20})?(?-i)['\"][0-9a-f]{32}['\"]'''
 	tags = ["key", "Facebook"]
 [[rules]]
+	id = "facebook-client"
 	description = "Facebook Client ID"
 	regex = '''(?i)(facebook|fb)(.{0,20})?['\"][0-9]{13,17}['\"]'''
 	tags = ["key", "Facebook"]
 [[rules]]
+	id = "twitter-key"
 	description = "Twitter Secret Key"
 	regex = '''(?i)twitter(.{0,20})?['\"][0-9a-z]{35,44}['\"]'''
 	tags = ["key", "Twitter"]
 [[rules]]
+	id = "twitter-id"
 	description = "Twitter Client ID"
 	regex = '''(?i)twitter(.{0,20})?['\"][0-9a-z]{18,25}['\"]'''
 	tags = ["client", "Twitter"]
 [[rules]]
+	id = "github"
 	description = "Github"
 	regex = '''(?i)github(.{0,20})?(?-i)['\"][0-9a-zA-Z]{35,40}['\"]'''
 	tags = ["key", "Github"]
 [[rules]]
+	id = "linkedin-id"
 	description = "LinkedIn Client ID"
 	regex = '''(?i)linkedin(.{0,20})?(?-i)['\"][0-9a-z]{12}['\"]'''
 	tags = ["client", "LinkedIn"]
 [[rules]]
+	id = "linkedin-key"
 	description = "LinkedIn Secret Key"
 	regex = '''(?i)linkedin(.{0,20})?['\"][0-9a-z]{16}['\"]'''
 	tags = ["secret", "LinkedIn"]
 [[rules]]
+	id = "slack"
 	description = "Slack"
 	regex = '''xox[baprs]-([0-9a-zA-Z]{10,48})?'''
 	tags = ["key", "Slack"]
 [[rules]]
+	id = "assymmetric key"
 	description = "Asymmetric Private Key"
 	regex = '''-----BEGIN ((EC|PGP|DSA|RSA|OPENSSH) )?PRIVATE KEY( BLOCK)?-----'''
 	tags = ["key", "AsymmetricPrivateKey"]
 [[rules]]
+	id = "generic-credential"
 	description = "Generic Credential"
 	regex = '''(?i)(api_key|apikey|secret)(.{0,20})?['|"][0-9a-zA-Z]{16,45}['|"]'''
 	tags = ["key", "API", "generic"]
@@ -59,56 +72,68 @@ title = "gitleaks config"
         paths = ['''magpie/security.py''']
         regexes = ['''randomsecretstring''']
 [[rules]]
+	id = "google-key"
 	description = "Google API key"
 	regex = '''AIza[0-9A-Za-z\\-_]{35}'''
 	tags = ["key", "Google"]
 [[rules]]
+	id = "heroku-key"
 	description = "Heroku API key"
 	regex = '''(?i)heroku(.{0,20})?['"][0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}['"]'''
 	tags = ["key", "Heroku"]
 [[rules]]
+	id = "mailchimp-key"
 	description = "MailChimp API key"
 	regex = '''(?i)(mailchimp|mc)(.{0,20})?['"][0-9a-f]{32}-us[0-9]{1,2}['"]'''
 	tags = ["key", "Mailchimp"]
 [[rules]]
+	id = "mailgun-key"
 	description = "Mailgun API key"
 	regex = '''(?i)(mailgun|mg)(.{0,20})?['"][0-9a-z]{32}['"]'''
 	tags = ["key", "Mailgun"]
 [[rules]]
+	id = "paypal-braintree-token"
 	description = "PayPal Braintree access token"
 	regex = '''access_token\$production\$[0-9a-z]{16}\$[0-9a-f]{32}'''
 	tags = ["key", "Paypal"]
 [[rules]]
+	id = "picatic-key"
 	description = "Picatic API key"
 	regex = '''sk_live_[0-9a-z]{32}'''
 	tags = ["key", "Picatic"]
 [[rules]]
+	id = "sendgrid-key"
 	description = "SendGrid API Key"
 	regex = '''SG\.[\w_]{16,32}\.[\w_]{16,64}'''
 	tags = ["key", "SendGrid"]
 [[rules]]
+	id = "slack-webhook"
 	description = "Slack Webhook"
 	regex = '''https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}'''
 	tags = ["key", "slack"]
 [[rules]]
+	id = "stripe-key"
 	description = "Stripe API key"
 	regex = '''(?i)stripe(.{0,20})?['\"][sk|rk]_live_[0-9a-zA-Z]{24}'''
 	tags = ["key", "Stripe"]
 [[rules]]
+	id = "square-token"
 	description = "Square access token"
 	regex = '''sq0atp-[0-9A-Za-z\-_]{22}'''
 	tags = ["key", "square"]
 [[rules]]
+	id = "square-secret"
 	description = "Square OAuth secret"
 	regex = '''sq0csp-[0-9A-Za-z\\-_]{43}'''
 	tags = ["key", "square"]
 [[rules]]
+	id = "twilio-key"
 	description = "Twilio API key"
 	regex = '''(?i)twilio(.{0,20})?['\"][0-9a-f]{32}['\"]'''
 	tags = ["key", "twilio"]
 [allowlist]
     description = "Allowlisted files"
-    files = [
+    paths = [
     # original contents
     '''^\.?gitleaks.toml$''',
     '''(.*?)(jpg|gif|doc|pdf|bin)$''',

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,44 +1,60 @@
 # label rules used by .github/workflows/label.yml
 
 api:
-  - canarieapi/api.py
-  - canarieapi/app_object.py
-  - canarieapi/reverse_proxied.py
-  - canarieapi/status.py
-  - canarieapi/utility_rest.py
-  - canarieapi/wsgi.py
+  - changed-files:
+    - any-glob-to-any-file:
+      - canarieapi/api.py
+      - canarieapi/app_object.py
+      - canarieapi/reverse_proxied.py
+      - canarieapi/status.py
+      - canarieapi/utility_rest.py
+      - canarieapi/wsgi.py
 
 config:
-  - canarieapi/default_configuration.py
-  - canarieapi/schema.py
+  - changed-files:
+    - any-glob-to-any-file:
+      - canarieapi/default_configuration.py
+      - canarieapi/schema.py
 
 monitor:
-  - canarieapi/logparser.py
-  - canarieapi/monitor.py
+  - changed-files:
+    - any-glob-to-any-file:
+      - canarieapi/logparser.py
+      - canarieapi/monitor.py
 
 # label 'ci' all automation-related steps and files
 ci:
-  - .*  # all '.<>' files
-  - .github/**/*
-  - ci/**/*
-  - hooks/**/*
-  - Makefile
-  - Dockerfile*
-  - setup.cfg
+  - changed-files:
+    - any-glob-to-any-file:
+      - .*  # all '.<>' files
+      - .github/**/*
+      - ci/**/*
+      - hooks/**/*
+      - Makefile
+      - Dockerfile*
+      - setup.cfg
 
 doc:
-  - "*.rst"
-  - "*.example"
-  - doc/**/*
-  - requirements-doc.txt
+  - changed-files:
+    - any-glob-to-any-file:
+      - "*.rst"
+      - "*.example"
+      - doc/**/*
+      - requirements-doc.txt
 
 db:
-  - canarieapi/database_schema.sql
+  - changed-files:
+    - any-glob-to-any-file:
+      - canarieapi/database_schema.sql
 
 tests:
-  - tests/**/*
-  - requirements-dev.txt
+  - changed-files:
+    - any-glob-to-any-file:
+      - tests/**/*
+      - requirements-dev.txt
 
 ui:
-  - canarieapi/static/*
-  - canarieapi/templates/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - canarieapi/static/*
+      - canarieapi/templates/*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,9 +28,10 @@ jobs:
       # enabled provenance attestation during build/push (see Makefile for details)
       DOCKER_PROV: "true"
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: "0"
+          persist-credentials: false
       - name: Get Tag Version
         id: version
         shell: bash

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,13 +6,12 @@ jobs:
   greeting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/first-interaction@v1
+    - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: >
+        issue-message: |
           Thanks for submitting an issue. Make sure you have checked for similar issues.
           Also, provide enough details for us to be able to replicate the problem.
-        pr-message: >
+        pr-message: |
           Thanks for submitting a PR. Make sure you have looked at the contribution guidelines.
           Also, look for quick check/tests operations that you can run locally for early verification of errors.
           Travis will be happier if it doesn't need to run too many times with problematic code.

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -12,7 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -31,28 +31,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: '0'
-      - name: Install dependencies
-        run: docker pull zricethezav/gitleaks
-      #- run: |
-      #    docker run --name=gitleaks --volume $GITHUB_WORKSPACE:/workspace/ \
-      #    -v --exclude-forks --redact --threads=1 --branch=$GITHUB_REF --repo-path=/workspace/
-      #- run: docker run --rm --name=gitleaks -v /tmp/:/code/ zricethezav/gitleaks -v --repo-path=/code/gitleaks
-      # @todo command is failing
-      #- run: gitleaks -v --exclude-forks --redact --threads=1 --branch=$GITHUB_REF --repo-path=$GITHUB_WORKSPACE
-
-      # FIXME: revert to original repo when (if) they ever consider the fix
-      #     https://github.com/eshork/gitleaks-action/pull/4
-      #     https://github.com/eshork/gitleaks-action/issues/3
-      #- uses: fmigneault/gitleaks-action@master
-      #- uses: eshork/gitleaks-action@v1.0.0
-      - uses: gitleaks/gitleaks-action@v1.6.0  # see: https://github.com/gitleaks/gitleaks-action/issues/57
-
-      # NOTE:
-      #   does the same as gitleaks-action, but over the whole git history + posts found problem on issue/PR comments
-      #   disable as it causes old (fixed) problems to be detected
-      #- uses: CySeq/gitcret@v2
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+      - name: Run prek
+        uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece # v3.0.0
+        with:
+          extra-args: '--all-files'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,11 +82,12 @@ jobs:
             allow-failure: true
             test-case: test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: "0"
+          persist-credentials: false
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         if: ${{ matrix.python-version != 'none' }}
         with:
           python-version: ${{ matrix.python-version }}
@@ -113,7 +114,7 @@ jobs:
       - name: Run Tests
         run: ${{ matrix.test-option }} make ${{ matrix.test-case }}-only
       - name: Upload coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ success() && matrix.test-case == 'coverage' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ ifeq ($(filter dry, $(MAKECMDGOALS)), dry)
 endif
 
 .PHONY: dry
-dry: setup.cfg	## run 'bump' target without applying changes (dry-run)
+dry: .bumpversion.toml	## run 'bump' target without applying changes (dry-run)
 ifeq ($(findstring bump, $(MAKECMDGOALS)),)
 	$(error Target 'dry' must be combined with a 'bump' target)
 endif
@@ -72,8 +72,8 @@ endif
 bump:	## bump version using VERSION specified as user input
 	@-echo "Updating package version ..."
 	@[ "${VERSION}" ] || ( echo ">> 'VERSION' is not set"; exit 1 )
-	@-bash -c '$(CONDA_CMD) test -f "$(CONDA_ENV_PATH)/bin/bump2version || pip install bump2version'
-	@-bash -c '$(CONDA_CMD) bump2version $(BUMP_XARGS) --new-version "${VERSION}" patch;'
+	@-bash -c '$(CONDA_CMD) test -f "$(CONDA_ENV_PATH)/bin/bump-my-version || pip install bump-my-version'
+	@-bash -c '$(CONDA_CMD) bump-my-version bump $(BUMP_XARGS) --new-version "${VERSION}" patch;'
 
 .PHONY: version
 version:	## display current version

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,6 @@
+default_language_version.python = "3.12"
+
+[[repos]]
+repo = "https://github.com/gitleaks/gitleaks"
+rev = "v8.30.1"
+hooks = [{ id = "gitleaks", args = ["--config=.github/.gitleaks.toml"] }]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,6 +14,7 @@ flake8-quotes
 flask_webtest
 isort>5.5
 mock
+prek
 pylint>=3,<4
 pylint-flask
 pylint-quotes

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 -r requirements-doc.txt
 autopep8
 bandit
-bump2version==1.0.1
+bump-my-version==1.4.1
 codacy-coverage>=1.3.11
 coverage>=5.5
 doc8>=0.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,36 +1,3 @@
-[bumpversion]
-current_version = 1.2.0
-commit = True
-tag = True
-tag_name = {new_version}
-
-[bumpversion:file:canarieapi/__meta__.py]
-search = __version__ = "{current_version}"
-replace = __version__ = "{new_version}"
-
-[bumpversion:file:Dockerfile]
-search = LABEL version="{current_version}"
-replace = LABEL version="{new_version}"
-
-[bumpversion:file:Makefile]
-search = APP_VERSION ?= {current_version}
-replace = APP_VERSION ?= {new_version}
-
-[bumpversion:file:CHANGES.rst]
-search = 
-	`Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
-	------------------------------------------------------------------------------------
-replace = 
-	`Unreleased <https://github.com/Ouranosinc/CanarieAPI/tree/master>`_ (latest)
-	------------------------------------------------------------------------------------
-	
-	.. **ADD LIST ITEMS WITH NEW CHANGES AND REMOVE THIS COMMENT**
-	
-	* No changes yet.
-	
-	`{new_version} <https://github.com/Ouranosinc/CanarieAPI/tree/{new_version}>`_ ({now:%%Y-%%m-%%d})
-	------------------------------------------------------------------------------------
-
 [doc8]
 max-line-length = 120
 ignore-path = docs/_build,docs/autoapi

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, py39, py310, py311
+envlist = py311, py312, py313, py314
 
 [testenv]
 setenv =


### PR DESCRIPTION
### Changes

- The `gitleaks` action has been replaced by `prek` (using the `prek.toml` configuration file) running the `gitleaks` pre-commit hooks.
  - The node version that the deprecated `gitleaks` version requires is being removed from the GitHub runner on September 16th, 2026; This at least keeps it going.
- `bump2version` has been replaced by `bump-my-version` (using the `.bumpversion.toml` configuration file).
  - `bump2version` is ancient while `bump-my-version` receives lots of maintenance and features.
- GitHub Actions have been updated to use commit hashes rather than mutable tag names.
- The `tox.ini` file has been slightly updated (for aesthetic reasons)